### PR TITLE
Add length to kwargs when its a FileField

### DIFF
--- a/rest_framework_friendly_errors/mixins.py
+++ b/rest_framework_friendly_errors/mixins.py
@@ -89,7 +89,9 @@ class FriendlyErrorMessagesMixin(FieldMap):
             kwargs.update({'input': field_data,
                            'input_type': type(field_data).__name__})
         elif field_type in self.field_map['file']:
-            kwargs.update({'max_length': field.max_length}),
+            kwargs.update({'max_length': field.max_length,
+                           'length': len(field.parent.data.get(
+                                field.source, ''))})
         elif field_type in self.field_map['composite']:
             kwargs.update({'input_type': type(field_data).__name__})
         elif field_type in self.field_map['relation']:


### PR DESCRIPTION
I encounter a bug when working with `FileField`. One of error messages have a `length` variable to format (sorry its in french :smile:):
- `empty`: _Le fichier soumis est vide._
- `no_name`: _Le nom de fichier n'a pu être déterminé._
- `max_length`: **Assurez-vous que le nom de fichier comporte au plus {max_length} caractères (il en comporte {length}).**
- `required`: _Aucun fichier n'a été soumis._
- `invalid`: _La donnée soumise n'est pas un fichier. Vérifiez le type d'encodage du formulaire._
- `null`: _Ce champ ne peut être nul._

`max_length` is already in kwargs but not `length`.
