### PR TITLE
Don't failed when using custom field

### DIFF
--- a/rest_framework_friendly_errors/mixins.py
+++ b/rest_framework_friendly_errors/mixins.py
@@ -169,7 +169,8 @@ class FriendlyErrorMessagesMixin(FieldMap):
                 code = self.FIELD_VALIDATION_ERRORS.get(name) or settings.FRIENDLY_VALIDATOR_ERRORS.get(name)
                 return {'code': code, 'field': field.field_name,
                         'message': error}
-        return {'code': settings.FRIENDLY_FIELD_ERRORS.get(field_type).get(key),
+        return {'code': settings.FRIENDLY_FIELD_ERRORS.get(
+                field_type, {}).get(key),
                 'field': field.field_name,
                 'message': error}
 


### PR DESCRIPTION
Avoid this error:

``` python
 File "[...]/drf-friendly-errors/rest_framework_friendly_errors/mixins.py", line 175, in <listcomp>
    return [self.get_field_error_entry(error, field) for error in errors]
  File "[...]/drf-friendly-errors/rest_framework_friendly_errors/mixins.py", line 170, in get_field_error_entry
    return {'code': settings.FRIENDLY_FIELD_ERRORS.get(field_type).get(key),
AttributeError: 'NoneType' object has no attribute 'get'
```
