### PR TITLE
Update settings.py to support Django 4.2

### DIFF
--- a/rest_framework_friendly_errors/settings.py
+++ b/rest_framework_friendly_errors/settings.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 
 from django.conf import settings
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from rest_framework_friendly_errors.utils import update_field_settings
 


### PR DESCRIPTION
`ugettext_lazy()` is no longer supported by recent versions of Django and has been deprecated in favor of its alias `gettext_lazy()`. ([reference](https://docs.djangoproject.com/en/4.0/releases/3.0/#id3))